### PR TITLE
Fix crush on Apple Silicon mac

### DIFF
--- a/src/main/java/com/sinthoras/hydroenergy/client/renderer/HETessalator.java
+++ b/src/main/java/com/sinthoras/hydroenergy/client/renderer/HETessalator.java
@@ -2,6 +2,7 @@ package com.sinthoras.hydroenergy.client.renderer;
 
 import com.sinthoras.hydroenergy.HE;
 import com.sinthoras.hydroenergy.HEUtil;
+import com.sinthoras.hydroenergy.config.HEConfig;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import java.nio.FloatBuffer;
@@ -131,6 +132,9 @@ public class HETessalator {
     }
 
     public static void render(ICamera camera) {
+        if (!GLContext.getCapabilities().OpenGL30 || HEConfig.useLimitedRendering) {
+            return;
+        }
         if (MinecraftForgeClient.getRenderPass() == HE.waterBlocks[0].getRenderBlockPass()) {
             final Frustrum frustrum = (Frustrum) camera;
             final float cameraBlockX = (float) frustrum.xPosition;


### PR DESCRIPTION
Right now, the HydroEnergy mod is the only mod that does not allow you to run the GregTech New Horizon build on an Apple Silicon processor.

When rendering the first frame, the HEWaterRenderer crashes. I couldn't come up with a nice workaround for this, so I temporarily suggest just not rendering this if the system doesn't support these methods.

[crash-2022-10-17_00.45.56-client.txt](https://github.com/GTNewHorizons/HydroEnergy/files/9795677/crash-2022-10-17_00.45.56-client.txt)

After the fix, everything works correctly, 40+ fps. Tested on Macbook Air M1 (Apple M1 GL version 2.1 Metal - 76.3, Apple)
