### PR TITLE
Fix crash with Angelica when looking at hydrodam pressurized water

### DIFF
--- a/src/main/java/com/sinthoras/hydroenergy/HETags.java
+++ b/src/main/java/com/sinthoras/hydroenergy/HETags.java
@@ -8,7 +8,7 @@ public class HETags {
     public static final String MODID = "GRADLETOKEN_MODID";
     public static final String MODNAME = "GRADLETOKEN_MODNAME";
     public static final String VERSION = "GRADLETOKEN_VERSION";
-    public static final String GROUPNAME = "GRADLETOKEN_GROUPNAME";
+    public static final String GROUPNAME = "com.sinthoras.hydroenergy";
     public static final String DEPENDENCIES = "required-after: gregtech;" + "required-after: tectech@[5.0,)";
 
     public static final String waterLevel = "walv";

--- a/src/main/java/com/sinthoras/hydroenergy/config/HEConfig.java
+++ b/src/main/java/com/sinthoras/hydroenergy/config/HEConfig.java
@@ -8,6 +8,7 @@ import net.minecraftforge.common.config.Property;
 
 import com.sinthoras.hydroenergy.HEUtil;
 
+import cpw.mods.fml.common.Loader;
 import gregtech.api.enums.GT_Values;
 
 public class HEConfig {
@@ -119,6 +120,8 @@ public class HEConfig {
                 "[CLIENT] Activate this if you have performance issues with the "
                         + "mod. But be warned: you will have limited render capabilities!");
         useLimitedRendering = useLimitedRenderingProperty.getBoolean();
+
+        if (Loader.isModLoaded("angelica")) useLimitedRendering = true;
 
         Property forceOpenGLProperty = configuration.get(
                 Categories.general,

--- a/src/main/java/com/sinthoras/hydroenergy/hooks/HEHooksFML.java
+++ b/src/main/java/com/sinthoras/hydroenergy/hooks/HEHooksFML.java
@@ -18,6 +18,7 @@ public class HEHooksFML {
 
     private float waterLevel = 85.0f;
     private int sign = 1;
+    private boolean isLoggedIn = false;
 
     @SubscribeEvent
     public void onEvent(ServerTickEvent event) {
@@ -43,14 +44,21 @@ public class HEHooksFML {
 
     @SideOnly(Side.CLIENT)
     @SubscribeEvent
+    public void onEvent(FMLNetworkEvent.ClientConnectedToServerEvent event) {
+        isLoggedIn = true;
+    }
+
+    @SideOnly(Side.CLIENT)
+    @SubscribeEvent
     public void onEvent(FMLNetworkEvent.ClientDisconnectionFromServerEvent event) {
         HEClient.onDisconnect();
+        isLoggedIn = false;
     }
 
     @SideOnly(Side.CLIENT)
     @SubscribeEvent
     public void onEvent(TickEvent.ClientTickEvent event) {
-        if (event.phase == TickEvent.Phase.END) {
+        if (event.phase == TickEvent.Phase.END && isLoggedIn) {
             HELightManager.onTick();
         }
     }


### PR DESCRIPTION
This is a workaround for https://github.com/GTNewHorizons/Angelica/issues/195, where the client crashes when looking at Hydrodam water. It makes the conditions of [this](https://github.com/GTNewHorizons/HydroEnergy/blob/master/src/main/java/com/sinthoras/hydroenergy/client/renderer/HEWaterRenderer.java#L49) statement false, causing it to use the seemingly Angelica compatible [alternative path](https://github.com/GTNewHorizons/HydroEnergy/blob/master/src/main/java/com/sinthoras/hydroenergy/client/renderer/HEWaterRenderer.java#L74) instead.

Note that I couldn't get the build system to replace the GRADLETOKEN_GROUPNAME token, so I replaced it manually for now. Let me know if there's a better way.