### PR TITLE
Disable `useDependencyInformation`

### DIFF
--- a/src/main/java/com/sinthoras/hydroenergy/HETags.java
+++ b/src/main/java/com/sinthoras/hydroenergy/HETags.java
@@ -9,7 +9,7 @@ public class HETags {
     public static final String MODNAME = "GRADLETOKEN_MODNAME";
     public static final String VERSION = "GRADLETOKEN_VERSION";
     public static final String GROUPNAME = "com.sinthoras.hydroenergy";
-    public static final String DEPENDENCIES = "required-after: gregtech;" + "required-after: tectech@[5.0,)";
+    public static final String DEPENDENCIES = "required-after:gregtech;required-after:tectech@[5.0,)";
 
     public static final String waterLevel = "walv";
     public static final String drainState = "drai";

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -11,10 +11,6 @@
 		"authorList": ["SinTh0r4s"],
 		"credits": "",
 		"logoFile": "",
-		"screenshots": [],
-		"requiredMods": ["Forge", "gregtech", "tectech"],
-		"dependencies": ["gregtech", "tectech"],
-		"dependants": [],
-		"useDependencyInformation": true
+		"screenshots": []
 	}]
 }


### PR DESCRIPTION
`"useDependencyInformation": true` overrides the dependencies declared in the `@Mod` annotation with the dependencies declared in this file.