### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/hydroenergy/lang/en_US.lang
+++ b/src/main/resources/assets/hydroenergy/lang/en_US.lang
@@ -1,1 +1,18 @@
 fluid.Pressurized Water=Pressurized Water
+
+tile.water0.name=Water
+tile.water1.name=Water
+tile.water2.name=Water
+tile.water3.name=Water
+tile.water4.name=Water
+tile.water5.name=Water
+tile.water6.name=Water
+tile.water7.name=Water
+tile.water8.name=Water
+tile.water9.name=Water
+tile.water10.name=Water
+tile.water11.name=Water
+tile.water12.name=Water
+tile.water13.name=tWater
+tile.water14.name=Water
+tile.water15.name=Water


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.