### PR TITLE
remove outdated tectech dep version

### DIFF
--- a/src/main/java/com/sinthoras/hydroenergy/HETags.java
+++ b/src/main/java/com/sinthoras/hydroenergy/HETags.java
@@ -9,7 +9,7 @@ public class HETags {
     public static final String MODNAME = "GRADLETOKEN_MODNAME";
     public static final String VERSION = "GRADLETOKEN_VERSION";
     public static final String GROUPNAME = "com.sinthoras.hydroenergy";
-    public static final String DEPENDENCIES = "required-after:gregtech;required-after:tectech@[5.0,)";
+    public static final String DEPENDENCIES = "required-after:gregtech;required-after:tectech";
 
     public static final String waterLevel = "walv";
     public static final String drainState = "drai";


### PR DESCRIPTION
It just constantly breaks builds for contributors that didnt clone gt properly to get tags.

It is also no longer correct since the mergening removed the tectech version from what I can see it and replaced it by the gt version. The goal here was not to check for gt4 :P

side note: as the mod hard depends on gt (and tectech, so certainly no other gt versions work either) we should switch it to gtnh-only in the mod-support doc.