### PR TITLE
Mixin fixes

### DIFF
--- a/src/main/java/com/sinthoras/hydroenergy/client/renderer/HETessalator.java
+++ b/src/main/java/com/sinthoras/hydroenergy/client/renderer/HETessalator.java
@@ -6,7 +6,6 @@ import java.util.Stack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GLAllocation;
 import net.minecraft.client.renderer.culling.Frustrum;
-import net.minecraft.client.renderer.culling.ICamera;
 import net.minecraft.client.settings.GameSettings;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.World;
@@ -137,12 +136,11 @@ public class HETessalator {
         numWaterBlocks++;
     }
 
-    public static void render(ICamera camera) {
+    public static void render(Frustrum frustrum) {
         if (!GLContext.getCapabilities().OpenGL30 || HEConfig.useLimitedRendering) {
             return;
         }
         if (MinecraftForgeClient.getRenderPass() == HE.waterBlocks[0].getRenderBlockPass()) {
-            final Frustrum frustrum = (Frustrum) camera;
             final float cameraBlockX = (float) frustrum.xPosition;
             final float cameraBlockY = (float) frustrum.yPosition;
             final float cameraBlockZ = (float) frustrum.zPosition;

--- a/src/main/java/com/sinthoras/hydroenergy/mixins/early/ActiveRenderInfoMixin.java
+++ b/src/main/java/com/sinthoras/hydroenergy/mixins/early/ActiveRenderInfoMixin.java
@@ -4,22 +4,23 @@ import net.minecraft.block.Block;
 import net.minecraft.client.renderer.ActiveRenderInfo;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.Vec3;
-import net.minecraft.world.ChunkPosition;
 import net.minecraft.world.World;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
+import com.llamalad7.mixinextras.sugar.Local;
 import com.sinthoras.hydroenergy.hooks.HEHooksUtil;
 
 @Mixin(ActiveRenderInfo.class)
 public class ActiveRenderInfoMixin {
 
-    private static Vec3 eyePosition;
+    @Unique
+    private static Vec3 he$eyePosition;
 
     // Grab eye position for subsequent redirect
     @Inject(
@@ -27,13 +28,11 @@ public class ActiveRenderInfoMixin {
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/world/World;getBlock(III)Lnet/minecraft/block/Block;",
-                    shift = At.Shift.BEFORE,
                     ordinal = 0),
-            require = 1,
-            locals = LocalCapture.CAPTURE_FAILEXCEPTION)
+            require = 1)
     private static void onGetEyePosition(World world, EntityLivingBase entity, float interpolationFactor,
-            CallbackInfoReturnable<Block> callbackInfoReturnable, Vec3 eyePosition, ChunkPosition blockPosition) {
-        ActiveRenderInfoMixin.eyePosition = eyePosition;
+            CallbackInfoReturnable<Block> cir, @Local Vec3 eyePosition) {
+        ActiveRenderInfoMixin.he$eyePosition = eyePosition;
     }
 
     // Redirect getBlock to check for custom water
@@ -45,6 +44,6 @@ public class ActiveRenderInfoMixin {
                     ordinal = 0),
             require = 1)
     private static Block redirectGetBlock(World world, int blockX, int blockY, int blockZ) {
-        return HEHooksUtil.getBlockForActiveRenderInfo(world.getBlock(blockX, blockY, blockZ), eyePosition);
+        return HEHooksUtil.getBlockForActiveRenderInfo(world.getBlock(blockX, blockY, blockZ), he$eyePosition);
     }
 }

--- a/src/main/java/com/sinthoras/hydroenergy/mixins/early/ChunkClientMixin.java
+++ b/src/main/java/com/sinthoras/hydroenergy/mixins/early/ChunkClientMixin.java
@@ -15,7 +15,7 @@ public class ChunkClientMixin {
     // Capture whole chunk update from server to check for custom water blocks and cache them
     @Inject(method = "fillChunk", at = @At("TAIL"), require = 1)
     private void onFillChunk(byte[] incomingData, int unusedFlags1, int unusedFlags2, boolean unusedFlag,
-            CallbackInfo callbackInfo) {
+            CallbackInfo ci) {
         HELightManager.onChunkDataLoad((Chunk) ((Object) this));
     }
 }

--- a/src/main/java/com/sinthoras/hydroenergy/mixins/early/ChunkMixin.java
+++ b/src/main/java/com/sinthoras/hydroenergy/mixins/early/ChunkMixin.java
@@ -2,14 +2,13 @@ package com.sinthoras.hydroenergy.mixins.early;
 
 import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.chunk.Chunk;
-import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
+import com.llamalad7.mixinextras.sugar.Local;
 import com.sinthoras.hydroenergy.client.light.HELightSMPHooks;
 
 @Mixin(value = Chunk.class, priority = 1100)
@@ -22,10 +21,9 @@ public class ChunkMixin {
                     value = "INVOKE",
                     target = "Lnet/minecraft/world/chunk/storage/ExtendedBlockStorage;setExtSkylightValue(IIII)V",
                     shift = At.Shift.AFTER),
-            require = 1,
-            locals = LocalCapture.CAPTURE_FAILEXCEPTION)
-    private void onSetExtBlocklight(CallbackInfo callbackInfo, int maxFilledChunkY, int blockX, int blockZ,
-            int lightValue, int blockY, int lightOpacity, ExtendedBlockStorage extendedBlockStorage) {
+            require = 1)
+    private void onSetExtBlocklight(CallbackInfo ci, @Local(ordinal = 1) int blockX, @Local(ordinal = 2) int blockZ,
+            @Local(ordinal = 4) int blockY) {
         HELightSMPHooks.onLightUpdate((Chunk) ((Object) this), blockX, blockY, blockZ);
     }
 
@@ -37,11 +35,10 @@ public class ChunkMixin {
                     target = "Lnet/minecraft/world/chunk/storage/ExtendedBlockStorage;setExtSkylightValue(IIII)V",
                     shift = At.Shift.AFTER,
                     ordinal = 0),
-            locals = LocalCapture.CAPTURE_FAILEXCEPTION,
             require = 0,
             expect = 0)
-    private void onRelightBlockSetExtBlockLightA(int blockX, int unusedBlockY, int blockZ, CallbackInfo callbackInfo,
-            int highestBlockY, int i1, int j1, int k1, int blockY, ExtendedBlockStorage extendedBlockStorage) {
+    private void onRelightBlockSetExtBlockLightA(int blockX, int unusedBlockY, int blockZ, CallbackInfo ci,
+            @Local(ordinal = 7) int blockY) {
         HELightSMPHooks.onLightUpdate((Chunk) ((Object) this), blockX, blockY, blockZ);
     }
 
@@ -53,11 +50,10 @@ public class ChunkMixin {
                     target = "Lnet/minecraft/world/chunk/storage/ExtendedBlockStorage;setExtSkylightValue(IIII)V",
                     shift = At.Shift.AFTER,
                     ordinal = 1),
-            locals = LocalCapture.CAPTURE_FAILEXCEPTION,
             require = 0,
             expect = 0)
-    private void onRelightBlockSetExtBlockLightB(int blockX, int unusedBlockY, int blockZ, CallbackInfo callbackInfo,
-            int highestBlockY, int i1, int j1, int k1, int blockY) {
+    private void onRelightBlockSetExtBlockLightB(int blockX, int unusedBlockY, int blockZ, CallbackInfo ci,
+            @Local(ordinal = 7) int blockY) {
         HELightSMPHooks.onLightUpdate((Chunk) ((Object) this), blockX, blockY, blockZ);
     }
 
@@ -69,11 +65,10 @@ public class ChunkMixin {
                     target = "Lnet/minecraft/world/chunk/storage/ExtendedBlockStorage;setExtSkylightValue(IIII)V",
                     shift = At.Shift.AFTER,
                     ordinal = 2),
-            locals = LocalCapture.CAPTURE_FAILEXCEPTION,
             require = 0,
             expect = 0)
-    private void onRelightBlockSetExtBlockLightC(int blockX, int unusedBlockY, int blockZ, CallbackInfo callbackInfo,
-            int highestBlockY, int blockY) {
+    private void onRelightBlockSetExtBlockLightC(int blockX, int unusedBlockY, int blockZ, CallbackInfo ci,
+            @Local(ordinal = 4) int blockY) {
         HELightSMPHooks.onLightUpdate((Chunk) ((Object) this), blockX, blockY, blockZ);
     }
 
@@ -86,7 +81,7 @@ public class ChunkMixin {
                     shift = At.Shift.AFTER),
             require = 1)
     private void onSetLightValue(EnumSkyBlock enumSkyBlock, int blockX, int blockY, int blockZ, int lightValue,
-            CallbackInfo callbackInfo) {
+            CallbackInfo ci) {
         HELightSMPHooks.onLightUpdate((Chunk) ((Object) this), blockX, blockY, blockZ);
     }
 }

--- a/src/main/java/com/sinthoras/hydroenergy/mixins/early/EntityRendererMixin.java
+++ b/src/main/java/com/sinthoras/hydroenergy/mixins/early/EntityRendererMixin.java
@@ -1,31 +1,28 @@
 package com.sinthoras.hydroenergy.mixins.early;
 
 import net.minecraft.client.renderer.EntityRenderer;
-import net.minecraft.client.renderer.RenderGlobal;
-import net.minecraft.client.renderer.culling.ICamera;
-import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.client.renderer.culling.Frustrum;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import com.llamalad7.mixinextras.sugar.Local;
 import com.sinthoras.hydroenergy.client.renderer.HETessalator;
 
 @Mixin(EntityRenderer.class)
 public class EntityRendererMixin {
 
-    // TODO: Simple Inject should be enough. But I remeber for fastcraft/optifine issues so i'll copy the ASM injection
-    // first
-    // Inject render call for lakes
-    @Redirect(
+    @Inject(
             method = "renderWorld",
             at = @At(
                     value = "INVOKE",
-                    target = "Lnet/minecraft/client/renderer/RenderGlobal;renderEntities(Lnet/minecraft/entity/EntityLivingBase;Lnet/minecraft/client/renderer/culling/ICamera;F)V"),
+                    target = "Lnet/minecraft/client/renderer/RenderGlobal;renderEntities(Lnet/minecraft/entity/EntityLivingBase;Lnet/minecraft/client/renderer/culling/ICamera;F)V",
+                    shift = At.Shift.AFTER),
             require = 1)
-    private void redirectRenderEntities(RenderGlobal renderGlobal, EntityLivingBase entitylivingbase, ICamera frustrum,
-            float p_78471_1_) {
-        renderGlobal.renderEntities(entitylivingbase, frustrum, p_78471_1_);
+    private void renderEntities(float p_78471_1_, long p_78471_2_, CallbackInfo ci,
+            @Local(name = "frustrum") Frustrum frustrum) {
         HETessalator.render(frustrum);
     }
 }

--- a/src/main/java/com/sinthoras/hydroenergy/mixins/early/WorldMixinClient.java
+++ b/src/main/java/com/sinthoras/hydroenergy/mixins/early/WorldMixinClient.java
@@ -2,15 +2,13 @@ package com.sinthoras.hydroenergy.mixins.early;
 
 import net.minecraft.block.Block;
 import net.minecraft.world.World;
-import net.minecraft.world.chunk.Chunk;
-import net.minecraftforge.common.util.BlockSnapshot;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
+import com.llamalad7.mixinextras.sugar.Local;
 import com.sinthoras.hydroenergy.client.light.HELightSMPHooks;
 
 @Mixin(value = World.class)
@@ -23,11 +21,9 @@ public class WorldMixinClient {
                     value = "INVOKE",
                     target = "Lnet/minecraft/world/chunk/Chunk;func_150807_a(IIILnet/minecraft/block/Block;I)Z",
                     shift = At.Shift.AFTER),
-            locals = LocalCapture.CAPTURE_FAILEXCEPTION,
             require = 1)
     private void onSetBlock(int blockX, int blockY, int blockZ, Block newBlock, int unused1, int unused2,
-            CallbackInfoReturnable<Boolean> callbackInfoReturnable, Chunk chunk, Block oldBlock,
-            BlockSnapshot blockSnapshot) {
+            CallbackInfoReturnable<Boolean> cir, @Local(ordinal = 1) Block oldBlock) {
         HELightSMPHooks.onSetBlock((World) ((Object) this), blockX, blockY, blockZ, newBlock, oldBlock);
     }
 }

--- a/src/main/java/com/sinthoras/hydroenergy/mixins/early/WorldRendererMixin.java
+++ b/src/main/java/com/sinthoras/hydroenergy/mixins/early/WorldRendererMixin.java
@@ -7,7 +7,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import com.sinthoras.hydroenergy.client.renderer.HETessalator;
 
@@ -24,7 +23,7 @@ public class WorldRendererMixin {
     public int posZ;
 
     // Update render cache about changes in rendered chunks
-    @Inject(method = "setPosition", at = @At("HEAD"), locals = LocalCapture.CAPTURE_FAILEXCEPTION, require = 1)
+    @Inject(method = "setPosition", at = @At("HEAD"), require = 1)
     private void onSetPosition(int blockX, int blockY, int blockZ, CallbackInfo callbackInfo) {
         if (blockX != posX || blockY != posY || blockZ != posZ) {
             HETessalator.onRenderChunkUpdate(posX, posZ, blockX, blockY, blockZ);


### PR DESCRIPTION
I wanted to remove the redirect of render entities because it always shows up in the profilers and that bothers me.

I also changed all the `@Injects` to use `@Local` capture instead of capturing all the locals.

Tested in full pack and looked at the diff and all injects are the same.